### PR TITLE
Eagerly set instance state to up

### DIFF
--- a/full_lifecycle_test.go
+++ b/full_lifecycle_test.go
@@ -217,6 +217,10 @@ func (f *fullLifecycleManagementHTTP) stepInstanceLaunchingNotification() {
 	assert.Nil(f.t, err)
 	assert.NotNil(f.t, la)
 	assert.Equal(f.t, "pending", f.vars["instance_launching_state"])
+
+	state, err := f.db.fetchInstanceState(f.vars["instance_id"])
+	assert.Nil(f.t, err)
+	assert.Equal(f.t, "up", state)
 }
 
 func (f *fullLifecycleManagementHTTP) stepInstanceLaunchingConfirmation() {

--- a/sns.go
+++ b/sns.go
@@ -91,6 +91,11 @@ func handleSNSNotification(db repo, log *logrus.Logger, msg *snsMessage) (int, e
 		if err != nil {
 			return http.StatusBadRequest, err
 		}
+		log.WithField("action", action).Debug("setting expected_state to up")
+		err = db.setInstanceState(action.EC2InstanceID, "up")
+		if err != nil {
+			return http.StatusBadRequest, err
+		}
 		return http.StatusOK, nil
 	case "autoscaling:EC2_INSTANCE_TERMINATING":
 		log.WithField("action", action).Debug("setting expected_state to down")


### PR DESCRIPTION
since heartbeats should succeed even if the launching lifecycle event doesn't
get confirmed