### PR TITLE
Support ephemeral instance lifecycle event tracking

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -40,6 +40,12 @@ func NewCLI() *cli.App {
 				Aliases: []string{"R"},
 				EnvVars: []string{"CYCLIST_REDIS_URL", "REDIS_URL"},
 			},
+			&cli.UintFlag{
+				Name:    "event-ttl",
+				Value:   uint(60 * 60 * 48),
+				Usage:   "duration in seconds since last update that instance lifecycle event data will be kept",
+				EnvVars: []string{"CYCLIST_EVENT_TTL", "EVENT_TTL"},
+			},
 			&cli.BoolFlag{
 				Name:    "debug",
 				Value:   false,
@@ -109,6 +115,8 @@ func runServeSetup(ctx *cli.Context) (*server, error) {
 	db := &redisRepo{
 		cg:  buildRedisPool(ctx.String("redis-url")),
 		log: log,
+
+		instEventTTL: ctx.Uint("event-ttl"),
 	}
 
 	snsSvc := sns.New(session.New(), &aws.Config{
@@ -155,6 +163,8 @@ func runSqsSetup(ctx *cli.Context) (*sqsHandler, context.Context, error) {
 	db := &redisRepo{
 		cg:  buildRedisPool(ctx.String("redis-url")),
 		log: log,
+
+		instEventTTL: ctx.Uint("event-ttl"),
 	}
 
 	sqsSvc := sqs.New(session.New())

--- a/db.go
+++ b/db.go
@@ -114,7 +114,7 @@ func (rr *redisRepo) fetchInstanceEvents(instanceID string) ([]*lifecycleEvent, 
 
 	for _, key := range revMapKeys {
 		keyParts := strings.SplitN(key, "::", 2)
-		events = append(events, newLifecycleEvent(revMap[key], keyParts[1]))
+		events = append(events, newLifecycleEvent(revMap[key], keyParts[0]))
 	}
 
 	return events, nil

--- a/db_test.go
+++ b/db_test.go
@@ -101,8 +101,8 @@ func TestRedisRepo_fetchInstanceEvents(t *testing.T) {
 
 	conn := rr.cg.Get().(*redigomock.Conn)
 	conn.Command("HGETALL", "cyclist:instance:i-fafafaf:events").ExpectMap(map[string]string{
-		"flipping": "2010-09-16T09:18:23.999999999Z04:00",
-		"loafing":  "2010-09-15T11:32:54.999999999Z04:00",
+		"flipping": "2010-09-16T09:18:23.999999999-04:00",
+		"loafing":  "2010-09-15T11:32:54.999999999-04:00",
 	})
 
 	events, err := rr.fetchInstanceEvents("i-fafafaf")

--- a/db_test.go
+++ b/db_test.go
@@ -67,6 +67,59 @@ func TestRedisRepo_wipeInstanceState_WithEmptyInstanceID(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestRedisRepo_storeInstanceEvent(t *testing.T) {
+	rr := &redisRepo{cg: &testRedisConnGetter{}, instEventTTL: uint(30)}
+
+	conn := rr.cg.Get().(*redigomock.Conn)
+	conn.Command("MULTI").Expect("OK!")
+	conn.Command("HSET",
+		"cyclist:instance:i-fafafaf:events",
+		"falafel", redigomock.NewAnyData()).Expect("OK!")
+	conn.Command("EXPIRE", "cyclist:instance:i-fafafaf:events", "30").Expect("OK!")
+	conn.Command("EXEC").Expect("OK!")
+
+	err := rr.storeInstanceEvent("i-fafafaf", "falafel")
+	assert.Nil(t, err)
+}
+
+func TestRedisRepo_storeInstanceEvent_WithEmptyInstanceID(t *testing.T) {
+	rr := &redisRepo{cg: &testRedisConnGetter{}}
+
+	err := rr.storeInstanceEvent("", "falafel")
+	assert.NotNil(t, err)
+}
+
+func TestRedisRepo_storeInstanceEvent_WithEmptyEvent(t *testing.T) {
+	rr := &redisRepo{cg: &testRedisConnGetter{}}
+
+	err := rr.storeInstanceEvent("i-fafafaf", "")
+	assert.NotNil(t, err)
+}
+
+func TestRedisRepo_fetchInstanceEvents(t *testing.T) {
+	rr := &redisRepo{cg: &testRedisConnGetter{}, instEventTTL: uint(30)}
+
+	conn := rr.cg.Get().(*redigomock.Conn)
+	conn.Command("HGETALL", "cyclist:instance:i-fafafaf:events").ExpectMap(map[string]string{
+		"flipping": "2010-09-16T09:18:23.999999999Z04:00",
+		"loafing":  "2010-09-15T11:32:54.999999999Z04:00",
+	})
+
+	events, err := rr.fetchInstanceEvents("i-fafafaf")
+	assert.Nil(t, err)
+	assert.NotNil(t, events)
+	assert.Len(t, events, 2)
+	assert.Equal(t, "loafing", events[0].Event)
+	assert.Equal(t, "flipping", events[1].Event)
+}
+
+func TestRedisRepo_fetchInstanceEvents_WithEmptyInstanceID(t *testing.T) {
+	rr := &redisRepo{cg: &testRedisConnGetter{}}
+
+	_, err := rr.fetchInstanceEvents("")
+	assert.NotNil(t, err)
+}
+
 func TestRedisRepo_storeInstanceLifecycleAction(t *testing.T) {
 	rr := &redisRepo{cg: &testRedisConnGetter{}}
 

--- a/full_lifecycle_test.go
+++ b/full_lifecycle_test.go
@@ -229,7 +229,7 @@ func (f *fullLifecycleManagementHTTP) stepInstanceLaunchingNotification() {
 	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
 	err = json.NewDecoder(res.Body).Decode(evs)
 	assert.Nil(f.t, err)
-	assert.Len(f.t, evs.Data, 0)
+	assert.Len(f.t, evs.Data, 1)
 }
 
 func (f *fullLifecycleManagementHTTP) stepInstanceLaunchingConfirmation() {
@@ -257,7 +257,7 @@ func (f *fullLifecycleManagementHTTP) stepInstanceLaunchingConfirmation() {
 	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
 	err = json.NewDecoder(res.Body).Decode(evs)
 	assert.Nil(f.t, err)
-	assert.Len(f.t, evs.Data, 1)
+	assert.Len(f.t, evs.Data, 2)
 }
 
 func (f *fullLifecycleManagementHTTP) stepHeartbeatWhileUp() {
@@ -280,7 +280,7 @@ func (f *fullLifecycleManagementHTTP) stepHeartbeatWhileUp() {
 	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
 	err = json.NewDecoder(res.Body).Decode(evs)
 	assert.Nil(f.t, err)
-	assert.Len(f.t, evs.Data, 2)
+	assert.Len(f.t, evs.Data, 3)
 }
 
 func (f *fullLifecycleManagementHTTP) stepInstanceTerminatingNotification() {
@@ -325,7 +325,7 @@ func (f *fullLifecycleManagementHTTP) stepInstanceTerminatingNotification() {
 	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
 	err = json.NewDecoder(res.Body).Decode(evs)
 	assert.Nil(f.t, err)
-	assert.Len(f.t, evs.Data, 2)
+	assert.Len(f.t, evs.Data, 4)
 }
 
 func (f *fullLifecycleManagementHTTP) stepHeartbeatWhileDown() {
@@ -348,7 +348,7 @@ func (f *fullLifecycleManagementHTTP) stepHeartbeatWhileDown() {
 	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
 	err = json.NewDecoder(res.Body).Decode(evs)
 	assert.Nil(f.t, err)
-	assert.Len(f.t, evs.Data, 2)
+	assert.Len(f.t, evs.Data, 4)
 }
 
 func (f *fullLifecycleManagementHTTP) stepInstanceTerminatingConfirmation() {
@@ -379,7 +379,7 @@ func (f *fullLifecycleManagementHTTP) stepInstanceTerminatingConfirmation() {
 	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
 	err = json.NewDecoder(res.Body).Decode(evs)
 	assert.Nil(f.t, err)
-	assert.Len(f.t, evs.Data, 3)
+	assert.Len(f.t, evs.Data, 5)
 }
 
 func TestFullLifecycleManagementSQS(t *testing.T) {

--- a/full_lifecycle_test.go
+++ b/full_lifecycle_test.go
@@ -222,6 +222,14 @@ func (f *fullLifecycleManagementHTTP) stepInstanceLaunchingNotification() {
 	state, err := f.db.fetchInstanceState(f.vars["instance_id"])
 	assert.Nil(f.t, err)
 	assert.Equal(f.t, "up", state)
+
+	res, err = http.Get(fmt.Sprintf("%s/events/%s", f.ts.URL, f.vars["instance_id"]))
+	assert.Nil(f.t, err)
+
+	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
+	err = json.NewDecoder(res.Body).Decode(evs)
+	assert.Nil(f.t, err)
+	assert.Len(f.t, evs.Data, 0)
 }
 
 func (f *fullLifecycleManagementHTTP) stepInstanceLaunchingConfirmation() {
@@ -241,7 +249,14 @@ func (f *fullLifecycleManagementHTTP) stepInstanceLaunchingConfirmation() {
 	state, err := f.db.fetchInstanceState(f.vars["instance_id"])
 	assert.Nil(f.t, err)
 	assert.Equal(f.t, "up", state)
-	assert.Equal(f.t, "completed", f.vars["instance_launching_state"])
+
+	res, err = http.Get(fmt.Sprintf("%s/events/%s", f.ts.URL, f.vars["instance_id"]))
+	assert.Nil(f.t, err)
+
+	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
+	err = json.NewDecoder(res.Body).Decode(evs)
+	assert.Nil(f.t, err)
+	assert.Len(f.t, evs.Data, 1)
 }
 
 func (f *fullLifecycleManagementHTTP) stepHeartbeatWhileUp() {
@@ -257,6 +272,14 @@ func (f *fullLifecycleManagementHTTP) stepHeartbeatWhileUp() {
 	state, err := f.db.fetchInstanceState(f.vars["instance_id"])
 	assert.Nil(f.t, err)
 	assert.Equal(f.t, "up", state)
+
+	res, err = http.Get(fmt.Sprintf("%s/events/%s", f.ts.URL, f.vars["instance_id"]))
+	assert.Nil(f.t, err)
+
+	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
+	err = json.NewDecoder(res.Body).Decode(evs)
+	assert.Nil(f.t, err)
+	assert.Len(f.t, evs.Data, 2)
 }
 
 func (f *fullLifecycleManagementHTTP) stepInstanceTerminatingNotification() {
@@ -294,6 +317,14 @@ func (f *fullLifecycleManagementHTTP) stepInstanceTerminatingNotification() {
 	state, err := f.db.fetchInstanceState(f.vars["instance_id"])
 	assert.Nil(f.t, err)
 	assert.Equal(f.t, "down", state)
+
+	res, err = http.Get(fmt.Sprintf("%s/events/%s", f.ts.URL, f.vars["instance_id"]))
+	assert.Nil(f.t, err)
+
+	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
+	err = json.NewDecoder(res.Body).Decode(evs)
+	assert.Nil(f.t, err)
+	assert.Len(f.t, evs.Data, 2)
 }
 
 func (f *fullLifecycleManagementHTTP) stepHeartbeatWhileDown() {
@@ -309,6 +340,14 @@ func (f *fullLifecycleManagementHTTP) stepHeartbeatWhileDown() {
 	state, err := f.db.fetchInstanceState(f.vars["instance_id"])
 	assert.Nil(f.t, err)
 	assert.Equal(f.t, "down", state)
+
+	res, err = http.Get(fmt.Sprintf("%s/events/%s", f.ts.URL, f.vars["instance_id"]))
+	assert.Nil(f.t, err)
+
+	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
+	err = json.NewDecoder(res.Body).Decode(evs)
+	assert.Nil(f.t, err)
+	assert.Len(f.t, evs.Data, 2)
 }
 
 func (f *fullLifecycleManagementHTTP) stepInstanceTerminatingConfirmation() {
@@ -332,6 +371,14 @@ func (f *fullLifecycleManagementHTTP) stepInstanceTerminatingConfirmation() {
 
 	assert.Len(f.t, f.db.(*testRepo).s, 0)
 	assert.Len(f.t, f.db.(*testRepo).la, 0)
+
+	res, err = http.Get(fmt.Sprintf("%s/events/%s", f.ts.URL, f.vars["instance_id"]))
+	assert.Nil(f.t, err)
+
+	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
+	err = json.NewDecoder(res.Body).Decode(evs)
+	assert.Nil(f.t, err)
+	assert.Len(f.t, evs.Data, 3)
 }
 
 func TestFullLifecycleManagementSQS(t *testing.T) {

--- a/full_lifecycle_test.go
+++ b/full_lifecycle_test.go
@@ -249,6 +249,7 @@ func (f *fullLifecycleManagementHTTP) stepInstanceLaunchingConfirmation() {
 	state, err := f.db.fetchInstanceState(f.vars["instance_id"])
 	assert.Nil(f.t, err)
 	assert.Equal(f.t, "up", state)
+	assert.Equal(f.t, "completed", f.vars["instance_launching_state"])
 
 	res, err = http.Get(fmt.Sprintf("%s/events/%s", f.ts.URL, f.vars["instance_id"]))
 	assert.Nil(f.t, err)

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func newInstanceHeartbeatHandlerFunc(db repo, log logrus.FieldLogger) http.HandlerFunc {
+func newHeartbeatHandlerFunc(db repo, log logrus.FieldLogger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		instanceID := vars["instance_id"]
@@ -17,6 +17,11 @@ func newInstanceHeartbeatHandlerFunc(db repo, log logrus.FieldLogger) http.Handl
 		if err != nil {
 			jsonRespond(w, http.StatusNotFound, &jsonErr{Err: err})
 			return
+		}
+
+		err = db.storeInstanceEvent(instanceID, "heartbeat")
+		if err != nil {
+			jsonRespond(w, http.StatusInternalServerError, &jsonErr{Err: err})
 		}
 
 		jsonRespond(w, http.StatusOK, &jsonInstanceState{State: state})

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -12,14 +12,41 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleLifecycleTransition(db repo, log logrus.FieldLogger, asSvc autoscalingiface.AutoScalingAPI, transition, instanceID string) error {
+var (
+	transitionHandlers = map[string]func(repo, string) error{
+		"launching":   handleLaunchingLifecycleTransition,
+		"terminating": handleTerminatingLifecycleTransition,
+	}
+)
+
+func handleLaunchingLifecycleTransition(db repo, instanceID string) error {
+	err := db.setInstanceState(instanceID, "up")
+	if err != nil {
+		return err
+	}
+
+	return db.storeInstanceEvent(instanceID, "launching")
+}
+
+func handleTerminatingLifecycleTransition(db repo, instanceID string) error {
+	err := db.wipeInstanceState(instanceID)
+	if err != nil {
+		return err
+	}
+
+	return db.storeInstanceEvent(instanceID, "terminating")
+}
+
+func handleLifecycleTransition(db repo, log logrus.FieldLogger,
+	asSvc autoscalingiface.AutoScalingAPI, transition, instanceID string) error {
 	action, err := db.fetchInstanceLifecycleAction(transition, instanceID)
 	if err != nil {
 		return err
 	}
 
 	if action == nil {
-		return fmt.Errorf("no lifecycle transition '%s' for instance '%s'", transition, instanceID)
+		return fmt.Errorf("no lifecycle transition '%s' for instance '%s'",
+			transition, instanceID)
 	}
 
 	input := &autoscaling.CompleteLifecycleActionInput{
@@ -31,7 +58,6 @@ func handleLifecycleTransition(db repo, log logrus.FieldLogger, asSvc autoscalin
 	}
 	_, err = asSvc.CompleteLifecycleAction(input)
 	if err != nil {
-
 		return err
 	}
 
@@ -40,23 +66,17 @@ func handleLifecycleTransition(db repo, log logrus.FieldLogger, asSvc autoscalin
 		log.WithField("err", err).Warn("failed to clean up lifecycle action bits")
 	}
 
-	switch transition {
-	case "launching":
-		err = db.setInstanceState(instanceID, "up")
-		if err != nil {
-			return err
-		}
-	case "terminating":
-		err = db.wipeInstanceState(instanceID)
-		if err != nil {
-			return err
-		}
+	if transitionHandler, ok := transitionHandlers[transition]; ok {
+		return transitionHandler(db, instanceID)
 	}
 
-	return nil
+	return fmt.Errorf("unknown lifecycle transition '%s'", transition)
 }
 
-func newInstanceLifecycleHandlerFunc(transition string, db repo, log logrus.FieldLogger, asSvc autoscalingiface.AutoScalingAPI) http.HandlerFunc {
+func newLifecycleHandlerFunc(transition string, db repo,
+	log logrus.FieldLogger,
+	asSvc autoscalingiface.AutoScalingAPI) http.HandlerFunc {
+
 	gerund := (map[string]string{
 		"launch":      "launching",
 		"termination": "terminating",
@@ -80,4 +100,35 @@ func newInstanceLifecycleHandlerFunc(transition string, db repo, log logrus.Fiel
 			Message: fmt.Sprintf("instance %s complete", transition),
 		})
 	}
+}
+
+func newLifecycleEventsHandlerFunc(db repo, log logrus.FieldLogger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log = log.WithFields(logrus.Fields{
+			"path":   r.URL.Path,
+			"method": r.Method,
+		})
+
+		instanceID := mux.Vars(r)["instance_id"]
+
+		events, err := db.fetchInstanceEvents(instanceID)
+		if err != nil {
+			jsonRespond(w, http.StatusBadRequest, &jsonErr{
+				Err: errors.Wrap(err, "fetching lifecycle events failed"),
+			})
+			return
+		}
+
+		jsonRespond(w, http.StatusOK, &jsonLifecycleEvents{
+			Data: events,
+			Meta: map[string]string{
+				"instance_id": instanceID,
+			},
+		})
+	}
+}
+
+type jsonLifecycleEvents struct {
+	Data []*lifecycleEvent `json:"data"`
+	Meta map[string]string `json:"meta"`
 }

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -90,6 +90,7 @@ func newLifecycleHandlerFunc(transition string, db repo,
 		err := handleLifecycleTransition(
 			db, log, asSvc, gerund, mux.Vars(r)["instance_id"])
 		if err != nil {
+			log.WithField("err", err).Error("handling lifecycle transition failed")
 			jsonRespond(w, http.StatusBadRequest, &jsonErr{
 				Err: errors.Wrap(err, "handling lifecycle transition failed"),
 			})
@@ -113,6 +114,7 @@ func newLifecycleEventsHandlerFunc(db repo, log logrus.FieldLogger) http.Handler
 
 		events, err := db.fetchInstanceEvents(instanceID)
 		if err != nil {
+			log.WithField("err", err).Error("fetching lifecycle events failed")
 			jsonRespond(w, http.StatusBadRequest, &jsonErr{
 				Err: errors.Wrap(err, "fetching lifecycle events failed"),
 			})

--- a/lifecycle_action.go
+++ b/lifecycle_action.go
@@ -2,18 +2,6 @@ package cyclist
 
 import "strings"
 
-// lifecycleAction is an SNS message payload of the form:
-// {
-//   "AutoScalingGroupName":"name string",
-//   "Service":"prose goop string",
-//   "Time":"iso 8601 timestamp string",
-//   "AccountId":"account id string",
-//   "LifecycleTransition":"transition string, e.g.: autoscaling:EC2_INSTANCE_TERMINATING",
-//   "RequestId":"uuid string",
-//   "LifecycleActionToken":"uuid string",
-//   "EC2InstanceId":"instance id string",
-//   "LifecycleHookName":"name string"
-// }
 type lifecycleAction struct {
 	Event                string
 	AutoScalingGroupName string `redis:"auto_scaling_group_name"`

--- a/lifecycle_event.go
+++ b/lifecycle_event.go
@@ -1,14 +1,17 @@
 package cyclist
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 var (
 	standardFluxCapacitorTime, _ = time.Parse(time.RFC3339, "1955-11-05T11:05:55-09:00")
 )
 
 type lifecycleEvent struct {
-	Event     string    `json:"event"`
-	Timestamp time.Time `json:"timestamp"`
+	Event     string
+	Timestamp time.Time
 }
 
 func newLifecycleEvent(event, ts string) *lifecycleEvent {
@@ -21,4 +24,13 @@ func newLifecycleEvent(event, ts string) *lifecycleEvent {
 		Event:     event,
 		Timestamp: timestamp,
 	}
+}
+
+func (le *lifecycleEvent) MarshalJSON() ([]byte, error) {
+	if le.Timestamp == standardFluxCapacitorTime || le.Timestamp.IsZero() {
+		return []byte(fmt.Sprintf(`{"event":%q,"timestamp":null}`, le.Event)), nil
+	}
+
+	return []byte(fmt.Sprintf(`{"event":%q,"timestamp":%q}`,
+		le.Event, le.Timestamp.Format(time.RFC3339Nano))), nil
 }

--- a/lifecycle_event.go
+++ b/lifecycle_event.go
@@ -1,0 +1,24 @@
+package cyclist
+
+import "time"
+
+var (
+	standardFluxCapacitorTime, _ = time.Parse(time.RFC3339, "1955-11-05T11:05:55-09:00")
+)
+
+type lifecycleEvent struct {
+	Event     string    `json:"event"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+func newLifecycleEvent(event, ts string) *lifecycleEvent {
+	timestamp, err := time.Parse(ts, time.RFC3339Nano)
+	if err != nil {
+		timestamp = standardFluxCapacitorTime
+	}
+
+	return &lifecycleEvent{
+		Event:     event,
+		Timestamp: timestamp,
+	}
+}

--- a/lifecycle_event.go
+++ b/lifecycle_event.go
@@ -12,7 +12,7 @@ type lifecycleEvent struct {
 }
 
 func newLifecycleEvent(event, ts string) *lifecycleEvent {
-	timestamp, err := time.Parse(ts, time.RFC3339Nano)
+	timestamp, err := time.Parse(time.RFC3339Nano, ts)
 	if err != nil {
 		timestamp = standardFluxCapacitorTime
 	}

--- a/lifecycle_event_test.go
+++ b/lifecycle_event_test.go
@@ -1,0 +1,39 @@
+package cyclist
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testLe = []struct {
+		e string
+		t string
+		j string
+	}{
+		{e: "", t: "", j: `{"event":"","timestamp":null}`},
+		{
+			e: "goo",
+			t: "2009-11-10T23:00:00Z",
+			j: `{"event":"goo","timestamp":"2009-11-10T23:00:00Z"}`,
+		},
+		{
+			e: "goose",
+			t: "19diggety2",
+			j: `{"event":"goose","timestamp":null}`,
+		},
+	}
+)
+
+func TestLifecycleEvent_MarshalJSON(t *testing.T) {
+	for _, tc := range testLe {
+		le := newLifecycleEvent(tc.e, tc.t)
+		buf := &bytes.Buffer{}
+		err := json.NewEncoder(buf).Encode(le)
+		assert.Nil(t, err)
+		assert.JSONEq(t, tc.j, buf.String())
+	}
+}

--- a/server.go
+++ b/server.go
@@ -64,13 +64,16 @@ func (srv *server) setupRouter() {
 	srv.router.HandleFunc(`/sns`, newSnsHandlerFunc(srv.db, srv.log, srv.snsSvc, srv.snsVerify)).Methods("POST")
 
 	srv.router.HandleFunc(`/heartbeats/{instance_id}`,
-		newInstanceHeartbeatHandlerFunc(srv.db, srv.log)).Methods("GET")
+		newHeartbeatHandlerFunc(srv.db, srv.log)).Methods("GET")
 
 	srv.router.Handle(`/launches/{instance_id}`,
-		srv.authd(newInstanceLifecycleHandlerFunc("launch", srv.db, srv.log, srv.asSvc))).Methods("POST")
+		srv.authd(newLifecycleHandlerFunc("launch", srv.db, srv.log, srv.asSvc))).Methods("POST")
 
 	srv.router.Handle(`/terminations/{instance_id}`,
-		srv.authd(newInstanceLifecycleHandlerFunc("termination", srv.db, srv.log, srv.asSvc))).Methods("POST")
+		srv.authd(newLifecycleHandlerFunc("termination", srv.db, srv.log, srv.asSvc))).Methods("POST")
+
+	srv.router.Handle(`/events/{instance_id}`,
+		newLifecycleEventsHandlerFunc(srv.db, srv.log)).Methods("GET")
 
 	srv.router.HandleFunc(`/`, srv.ohai).Methods("GET", "HEAD")
 }

--- a/sns.go
+++ b/sns.go
@@ -110,6 +110,10 @@ func handleSNSNotification(db repo, log logrus.FieldLogger, msg *snsMessage) (in
 		if err != nil {
 			return http.StatusBadRequest, err
 		}
+		err = db.storeInstanceEvent(action.EC2InstanceID, "prelaunching")
+		if err != nil {
+			return http.StatusBadRequest, err
+		}
 		return http.StatusOK, nil
 	case "autoscaling:EC2_INSTANCE_TERMINATING":
 		log.WithField("action", action).Debug("setting expected_state to down")
@@ -119,6 +123,10 @@ func handleSNSNotification(db repo, log logrus.FieldLogger, msg *snsMessage) (in
 		}
 		log.WithField("action", action).Debug("storing instance terminating lifecycle action")
 		err = db.storeInstanceLifecycleAction(action)
+		if err != nil {
+			return http.StatusBadRequest, err
+		}
+		err = db.storeInstanceEvent(action.EC2InstanceID, "preterminating")
 		if err != nil {
 			return http.StatusBadRequest, err
 		}


### PR DESCRIPTION
This is not a full event audit per instance, but instead last-in captures the following named events with timestamps.  The only event that is expected to occur multiple times is `heartbeat`.
- `prelaunching` - an SNS notification has been received with an `autoscaling:EC2_INSTANCE_LAUNCHING` transition for a given instance with token for confirmation after the instance "phones home" with...
- `launching` - an instance has "phoned home" once it begins to receive work.  In the case of [travis-worker](https://github.com/travis-ci/worker), this happens when a "start hook" is executed.
- `heartbeat` - something has hit `GET /heartbeats/{instance_id}`, which is an unauthenticated route, so hopefully it was the instance.  maybe.
- `preterminating` - an SNS notification has been received with an `autoscaling:EC2_INSTANCE_TERMINATING` transition for a given instance with a token for confirmation after the instance "phones home"
- `terminating` - an instance has "phoned home" once it has stopped receiving work.  In the case of [travis-worker](https://github.com/travis-ci/worker), this happens when a "stop hook" is executed.
