### PR TITLE
Add GET /events for fetching all known lifecycle events

### DIFF
--- a/full_lifecycle_test.go
+++ b/full_lifecycle_test.go
@@ -258,10 +258,10 @@ func (f *fullLifecycleManagementHTTP) stepGetInstanceToken() {
 	assert.Nil(f.t, err)
 	assert.Equal(f.t, 200, res.StatusCode)
 
-	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
+	evs := &jsonLifecycleEvents{}
 	err = json.NewDecoder(res.Body).Decode(evs)
 	assert.Nil(f.t, err)
-	assert.Len(f.t, evs.Data, 1)
+	assert.Len(f.t, evs.Events, 1)
 }
 
 func (f *fullLifecycleManagementHTTP) stepInstanceLaunchingConfirmation() {
@@ -288,10 +288,10 @@ func (f *fullLifecycleManagementHTTP) stepInstanceLaunchingConfirmation() {
 	assert.Nil(f.t, err)
 	assert.Equal(f.t, 200, res.StatusCode)
 
-	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
+	evs := &jsonLifecycleEvents{}
 	err = json.NewDecoder(res.Body).Decode(evs)
 	assert.Nil(f.t, err)
-	assert.Len(f.t, evs.Data, 2)
+	assert.Len(f.t, evs.Events, 2)
 }
 
 func (f *fullLifecycleManagementHTTP) stepHeartbeatWhileUp() {
@@ -312,10 +312,10 @@ func (f *fullLifecycleManagementHTTP) stepHeartbeatWhileUp() {
 	assert.Nil(f.t, err)
 	assert.Equal(f.t, 200, res.StatusCode)
 
-	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
+	evs := &jsonLifecycleEvents{}
 	err = json.NewDecoder(res.Body).Decode(evs)
 	assert.Nil(f.t, err)
-	assert.Len(f.t, evs.Data, 3)
+	assert.Len(f.t, evs.Events, 3)
 }
 
 func (f *fullLifecycleManagementHTTP) stepInstanceTerminatingNotification() {
@@ -358,10 +358,10 @@ func (f *fullLifecycleManagementHTTP) stepInstanceTerminatingNotification() {
 	assert.Nil(f.t, err)
 	assert.Equal(f.t, 200, res.StatusCode)
 
-	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
+	evs := &jsonLifecycleEvents{}
 	err = json.NewDecoder(res.Body).Decode(evs)
 	assert.Nil(f.t, err)
-	assert.Len(f.t, evs.Data, 4)
+	assert.Len(f.t, evs.Events, 4)
 }
 
 func (f *fullLifecycleManagementHTTP) stepHeartbeatWhileDown() {
@@ -382,10 +382,10 @@ func (f *fullLifecycleManagementHTTP) stepHeartbeatWhileDown() {
 	assert.Nil(f.t, err)
 	assert.Equal(f.t, 200, res.StatusCode)
 
-	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
+	evs := &jsonLifecycleEvents{}
 	err = json.NewDecoder(res.Body).Decode(evs)
 	assert.Nil(f.t, err)
-	assert.Len(f.t, evs.Data, 4)
+	assert.Len(f.t, evs.Events, 4)
 }
 
 func (f *fullLifecycleManagementHTTP) stepInstanceTerminatingConfirmation() {
@@ -415,10 +415,10 @@ func (f *fullLifecycleManagementHTTP) stepInstanceTerminatingConfirmation() {
 	assert.Nil(f.t, err)
 	assert.Equal(f.t, 200, res.StatusCode)
 
-	evs := &jsonLifecycleEvents{Meta: map[string]string{}}
+	evs := &jsonLifecycleEvents{}
 	err = json.NewDecoder(res.Body).Decode(evs)
 	assert.Nil(f.t, err)
-	assert.Len(f.t, evs.Data, 5)
+	assert.Len(f.t, evs.Events, 5)
 }
 
 func TestFullLifecycleManagementSQS(t *testing.T) {

--- a/package_test.go
+++ b/package_test.go
@@ -112,6 +112,19 @@ func (tr *testRepo) fetchInstanceEvents(instanceID string) ([]*lifecycleEvent, e
 	return events, nil
 }
 
+func (tr *testRepo) fetchAllInstanceEvents() (map[string][]*lifecycleEvent, error) {
+	ret := map[string][]*lifecycleEvent{}
+
+	for instanceID, eventsMap := range tr.e {
+		ret[instanceID] = []*lifecycleEvent{}
+		for _, event := range eventsMap {
+			ret[instanceID] = append(ret[instanceID], event)
+		}
+	}
+
+	return ret, nil
+}
+
 func (tr *testRepo) storeInstanceLifecycleAction(la *lifecycleAction) error {
 	if la.LifecycleTransition == "" || la.EC2InstanceID == "" ||
 		la.LifecycleActionToken == "" || la.AutoScalingGroupName == "" ||

--- a/server.go
+++ b/server.go
@@ -87,6 +87,9 @@ func (srv *server) setupRouter() {
 	srv.router.Handle(`/events/{instance_id}`,
 		srv.instAuthd(newLifecycleEventsHandlerFunc(srv.db, srv.log))).Methods("GET")
 
+	srv.router.Handle(`/events`,
+		srv.authd(newAllLifecycleEventsHandlerFunc(srv.db, srv.log))).Methods("GET")
+
 	srv.router.HandleFunc(`/`, srv.ohai).Methods("GET", "HEAD")
 	srv.router.HandleFunc(`/__meta__`, srv.meta).Methods("GET", "HEAD")
 }


### PR DESCRIPTION
meant for consumption by humans, scripts, automation.  I found myself wanting this, and was messing with redis directly instead, so here it is.