### PR TITLE
Add `set-down` command

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -140,15 +140,7 @@ func runServe(ctx *cli.Context) error {
 
 func runSetDown(ctx *cli.Context) error {
 	log := buildLog(ctx.Bool("debug"))
-	db := &redisRepo{
-		cg:  buildRedisPool(ctx.String("redis-url")),
-		log: log,
-
-		instEventTTL:           uint(ctx.Duration("event-ttl").Seconds()),
-		instLifecycleActionTTL: uint(ctx.Duration("lifecycle-action-ttl").Seconds()),
-		instTempTokTTL:         uint(ctx.Duration("temp-token-ttl").Seconds()),
-		instTokTTL:             uint(ctx.Duration("token-ttl").Seconds()),
-	}
+	db := setupDbFromCtxAndLog(ctx, log)
 
 	for _, instanceID := range ctx.StringSlice("instances") {
 		err := db.setInstanceState(instanceID, "down")
@@ -171,15 +163,7 @@ func runServeSetup(ctx *cli.Context) (*server, error) {
 	}
 
 	log := buildLog(ctx.Bool("debug"))
-	db := &redisRepo{
-		cg:  buildRedisPool(ctx.String("redis-url")),
-		log: log,
-
-		instEventTTL:           uint(ctx.Duration("event-ttl").Seconds()),
-		instLifecycleActionTTL: uint(ctx.Duration("lifecycle-action-ttl").Seconds()),
-		instTempTokTTL:         uint(ctx.Duration("temp-token-ttl").Seconds()),
-		instTokTTL:             uint(ctx.Duration("token-ttl").Seconds()),
-	}
+	db := setupDbFromCtxAndLog(ctx, log)
 
 	snsSvc := sns.New(session.New(), &aws.Config{
 		Region: aws.String(ctx.String("aws-region")),
@@ -205,6 +189,18 @@ func runServeSetup(ctx *cli.Context) (*server, error) {
 
 		snsVerify: true,
 	}, nil
+}
+
+func setupDbFromCtxAndLog(ctx *cli.Context, log logrus.FieldLogger) repo {
+	return &redisRepo{
+		cg:  buildRedisPool(ctx.String("redis-url")),
+		log: log,
+
+		instEventTTL:           uint(ctx.Duration("event-ttl").Seconds()),
+		instLifecycleActionTTL: uint(ctx.Duration("lifecycle-action-ttl").Seconds()),
+		instTempTokTTL:         uint(ctx.Duration("temp-token-ttl").Seconds()),
+		instTokTTL:             uint(ctx.Duration("token-ttl").Seconds()),
+	}
 }
 
 /* TODO: #5

--- a/db.go
+++ b/db.go
@@ -364,7 +364,7 @@ func (rr *redisRepo) fetchInstanceTokenfTTL(fmtString, instanceID string, ttl ui
 
 func (rr *redisRepo) closeConn(conn redis.Conn) {
 	err := conn.Close()
-	if err != nil {
+	if err != nil && rr.log != nil {
 		rr.log.WithField("err", err).Error("failed to close redis conn")
 	}
 }


### PR DESCRIPTION
to be used via `heroku run` for setting instance state to "down", which triggers a graceful shutdown.  The current way of doing this requires direct access to redis, which risks corrupting the data, which is why I'm adding this command.