### PR TITLE
return nil on missing lifecycle action

### DIFF
--- a/db.go
+++ b/db.go
@@ -274,6 +274,10 @@ func (rr *redisRepo) fetchInstanceLifecycleAction(transition, instanceID string)
 		return nil, err
 	}
 
+	if len(attrs) == 0 {
+		return nil, nil
+	}
+
 	ala := &lifecycleAction{}
 	err = redis.ScanStruct(attrs, ala)
 	if err != nil {


### PR DESCRIPTION
Redis HGETALL returns an empty list when accessing a missing key. The calling
code in this case is expecting fetchInstanceLifecycleAction() to return nil
in case of a missing action.

Missing action may happen when an instance posts against /terminations/<id>
after imploding. In that case it never received a termination request, so
there is no action to fetch.